### PR TITLE
Add terraform plan workflow

### DIFF
--- a/.github/workflows/terraform-plan-ecs-v1.yml
+++ b/.github/workflows/terraform-plan-ecs-v1.yml
@@ -1,0 +1,132 @@
+name: Terraform plan for ecs applications
+
+on:
+  workflow_call:
+    inputs:
+      aws_region:
+        type: string
+        default: "eu-central-1"
+      service:
+        type: string
+        required: true
+      environments:
+        type: string
+        default: "['preproduction', 'production']"
+      self_hosted:
+        type: boolean
+        default: false
+      terraform_version:
+        type: string
+        required: true
+      working_directory:
+        type: string
+        default: "./infra/terraform"
+
+jobs:
+  plan:
+    runs-on: ${{ inputs.self_hosted && fromJSON(format('["self-hosted","{0}"]', matrix.environment)) || 'ubuntu-latest' }}
+    defaults:
+      run:
+        working-directory: ${{ inputs.working_directory }}
+    strategy:
+      # we want both plans to complete if one fails
+      fail-fast: false
+      matrix:
+        # Array input type is currently not supported https://github.com/community/community/discussions/11692
+        environment: ${{ fromJson(inputs.environments) }}
+    env:
+      AWS_DEFAULT_REGION: ${{ inputs.aws_region }}
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      SERVICE: ${{ inputs.service }}
+      ENV: ${{ matrix.environment }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      TF_WORKSPACE: ${{ matrix.environment }}
+      TF_LOG: INFO
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+        # get the current image tag to avoid displaying in a diff in each PR
+        # while this information would be accurate (the task definition is going to change)
+        # it will be more efficient to display the diff only when there's a real infstracture change
+        # if we display the same message on each PR users will get the habit to ignore it 
+        # and will likely ignore it the day it really matters
+      - name: Get current image tag
+        run: |
+          REF=$(aws ecs describe-task-definition --task-definition "${SERVICE}-${ENV}" --output json | jq -r '.taskDefinition.containerDefinitions[] | select(.name == "'${SERVICE}'") | .image | split(":")[1]')
+          echo ${REF}
+          echo "REF=$REF" >> ${GITHUB_ENV}
+
+      - name: Terraform setup
+        uses: hashicorp/setup-terraform@v1
+        with:
+          terraform_version: ${{ inputs.terraform_version }}
+
+      - name: Terraform init
+        run: terraform init
+
+      - name: Terraform validate
+        run: terraform validate
+
+      # inspired by https://blog.testdouble.com/posts/2021-12-07-elevate-your-terraform-workflow-with-github-actions/
+      - name: Terraform plan
+        id: plan
+        continue-on-error: true
+        run: |
+          terraform plan -var-file=${ENV}.tfvars -var docker_image_tag=${REF} -input=false -no-color -out=tfplan \
+          && terraform show -no-color tfplan | sed 's/\x27/ /g'
+
+      - name: Reformat Plan
+        run: |
+          echo '${{ steps.plan.outputs.stdout || steps.plan.outputs.stderr }}' \
+          | sed -E 's/^([[:space:]]+)([-+])/\2\1/g' > plan.txt
+
+      - name: Put Plan in Env Var
+        run: |
+          PLAN=$(cat plan.txt)
+          echo "PLAN<<EOF" >> $GITHUB_ENV
+          echo "$PLAN" >> $GITHUB_ENV
+          echo "EOF" >> $GITHUB_ENV
+
+      - uses: actions/github-script@v6
+        if: github.event_name == 'pull_request'
+        env:
+          PLAN: "terraform\n${{ steps.plan.outputs.stdout }}"
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            })
+            const commentTitle = 'Terraform Plan \`${{ matrix.environment  }}\`'
+            const botComment = comments.find(comment => {
+              return comment.user.type === 'Bot' && comment.body.includes(commentTitle)
+            })
+            const output = `#### ${commentTitle}
+            \`\`\`diff\n
+            ${{ env.PLAN }}
+            \`\`\`
+            <details>
+              <summary> More about this </summary>
+              This diff doesn't display the upcoming image version change as the new tag version will be computed after the merge.
+            </details>`
+
+            // Update a comment if it already exists
+            if (botComment) {
+              github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: botComment.id,
+                body: output
+              })
+            } else {
+              github.rest.issues.createComment({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body: output
+              })
+            }

--- a/.github/workflows/terraform-plan-v1.yml
+++ b/.github/workflows/terraform-plan-v1.yml
@@ -1,0 +1,113 @@
+name: Terraform plan
+
+on:
+  workflow_call:
+    inputs:
+      aws_region:
+        type: string
+        default: "eu-central-1"
+      environments:
+        type: string
+        default: "['preproduction', 'production']"
+      self_hosted:
+        type: boolean
+        default: false
+      terraform_version:
+        type: string
+        required: true
+      working_directory:
+        type: string
+        required: true
+
+jobs:
+  plan:
+    runs-on: ${{ inputs.self_hosted && fromJSON(format('["self-hosted","{0}"]', matrix.environment)) || 'ubuntu-latest' }}
+    defaults:
+      run:
+        working-directory: ${{ inputs.working_directory }}
+    strategy:
+      # we want both plans to complete if one fails
+      fail-fast: false
+      matrix:
+        # Array input type is currently not supported https://github.com/community/community/discussions/11692
+        environment: ${{ fromJson(inputs.environments) }}
+    env:
+      AWS_DEFAULT_REGION: ${{ inputs.aws_region }}
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      ENV: ${{ matrix.environment }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      TF_WORKSPACE: ${{ matrix.environment }}
+      TF_LOG: INFO
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Terraform setup
+        uses: hashicorp/setup-terraform@v1
+        with:
+          terraform_version: ${{ inputs.terraform_version }}
+
+      - name: Terraform init
+        run: terraform init
+
+      - name: Terraform validate
+        run: terraform validate
+
+      # inspired by https://blog.testdouble.com/posts/2021-12-07-elevate-your-terraform-workflow-with-github-actions/
+      - name: Terraform plan
+        id: plan
+        continue-on-error: true
+        run: |
+          terraform plan -var-file=${ENV}.tfvars -input=false -no-color -out=tfplan \
+          && terraform show -no-color tfplan | sed 's/\x27/ /g'
+
+      - name: Reformat Plan
+        run: |
+          echo '${{ steps.plan.outputs.stdout || steps.plan.outputs.stderr }}' \
+          | sed -E 's/^([[:space:]]+)([-+])/\2\1/g' > plan.txt
+
+      - name: Put Plan in Env Var
+        run: |
+          PLAN=$(cat plan.txt)
+          echo "PLAN<<EOF" >> $GITHUB_ENV
+          echo "$PLAN" >> $GITHUB_ENV
+          echo "EOF" >> $GITHUB_ENV
+
+      - uses: actions/github-script@v6
+        if: github.event_name == 'pull_request'
+        env:
+          PLAN: "terraform\n${{ steps.plan.outputs.stdout }}"
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            })
+            const commentTitle = 'Terraform Plan \`${{ matrix.environment  }}\`'
+            const botComment = comments.find(comment => {
+              return comment.user.type === 'Bot' && comment.body.includes(commentTitle)
+            })
+            const output = `#### ${commentTitle}
+            \`\`\`diff\n
+            ${{ env.PLAN }}
+            \`\`\`
+            `
+            // Update a comment if it already exists
+            if (botComment) {
+              github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: botComment.id,
+                body: output
+              })
+            } else {
+              github.rest.issues.createComment({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body: output
+              })
+            }

--- a/README.md
+++ b/README.md
@@ -1,2 +1,24 @@
 # github-workflows
 Common Github Actions workflows
+
+## terraform-plan-ecs
+
+Perform a terraform plan against preprod and prod deplyoment for a [standard ECS fargate service](https://github.com/sencrop/terraform-modules).
+
+```yaml
+jobs:
+  terraform:
+    uses: sencrop/github-workflows/.github/workflows/terraform-plan-ecs-v1.yml
+    secrets: inherit
+    with:
+      service: "my-service"
+      terraform_version: "1.2.9"
+
+```
+
+If the application is deployed on a single environment you can override the list of environments.
+
+```yaml
+    with:
+      environments: "['preproduction']"
+```

--- a/README.md
+++ b/README.md
@@ -1,9 +1,33 @@
 # github-workflows
 Common Github Actions workflows
 
+## terraform-plan
+
+Perform a terraform plan  against `preproduction` and `production` environment and post the result to the pull request.
+
+```yaml
+jobs:
+  terraform:
+    uses: sencrop/github-workflows/.github/workflows/terraform-plan-v1.yml
+    secrets: inherit
+    with:
+      terraform_version: "1.2.9"
+      working_directory: "./terraform"
+
+```
+
+The list of environment can be overrided using the `environment` variable.
+
+```yaml
+    with:
+      environments: "['preproduction']"
+```
+
 ## terraform-plan-ecs
 
-Perform a terraform plan against preprod and prod deplyoment for a [standard ECS fargate service](https://github.com/sencrop/terraform-modules).
+This is a more specialized version of the terraform plan workflow dedicated to [standard ECS fargate service](https://github.com/sencrop/terraform-modules).  
+The main is that difference is that it will get the currrently deployed docker image tag version on aws and pass it to the plan.
+
 
 ```yaml
 jobs:
@@ -14,11 +38,4 @@ jobs:
       service: "my-service"
       terraform_version: "1.2.9"
 
-```
-
-If the application is deployed on a single environment you can override the list of environments.
-
-```yaml
-    with:
-      environments: "['preproduction']"
 ```


### PR DESCRIPTION
Create a common Github workflow to display terraform plan in Github. This should help be helpful in different ways:

- Reviewers of a terraform change would easily read the plan
- Running local terraform plan can be tedious (you need to get the creds and the command line parameter right) or too heavy to run locally.
- Changes to [terraform-modules](https://github.com/sencrop/terraform-modules) are propagated silently to applications, this will make them visible.

Implementation choices:
- The plan is performed against the `preproduction` and `production` environment using the current image tag. This way we avoid displaying a plan that has upcoming changes in each PR but only when there is substantial infrastructure changes.
- The Github message is as light as possible to make changes as visible as possible when they occur.
- This workflow is focused on running terraform plan for our ecs application (today about 15 apps). We might create another flavour of this for other use cases (I think that we should avoid having a single `terraform plan` workflow with `if` all over the place).


Example of usage

```yaml
jobs:
  terraform:
    uses: sencrop/github-workflows/.github/workflows/terraform-plan-ecs-v1.yml
    secrets: inherit
    with:
      service: "my-service"
      terraform_version: "1.2.9"
```

[output example](https://github.com/sencrop/sencrop-bali-api/pull/1229)