### PR TITLE
Add a new workflow to deploy ecs applications

### DIFF
--- a/.github/workflows/ecs-deploy-v1.yml
+++ b/.github/workflows/ecs-deploy-v1.yml
@@ -1,0 +1,84 @@
+---
+name: Deploy a standard ECS application
+
+on:
+  workflow_call:
+    inputs:
+      aws_region:
+        type: string
+        default: "eu-central-1"
+      docker_image_tag:
+        type: string
+        required: true
+      environment:
+        type: string
+        required: true
+      self_hosted:
+        type: boolean
+        default: false
+      service:
+        type: string
+        required: true
+      slack_channel:
+        type: string
+        required: true
+      terraform_version:
+        type: string
+        required: true
+      working_directory:
+        type: string
+        default: "./infra/terraform"
+
+jobs:
+  deploy:
+    runs-on: ${{ inputs.self_hosted && fromJSON(format('["self-hosted","{0}"]', inputs.environment)) || 'ubuntu-latest' }}
+    defaults:
+      run:
+        working-directory: ${{ inputs.working_directory }}
+    env:
+      AWS_DEFAULT_REGION: ${{ inputs.aws_region }}
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      DOCKER_IMAGE_TAG: ${{ inputs.docker_image_tag }}
+      ENV: ${{ inputs.environment }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      SERVICE: ${{ inputs.service }}
+      TF_WORKSPACE: ${{ inputs.environment }}
+      TF_LOG: INFO
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Terraform setup
+        uses: hashicorp/setup-terraform@v2
+        with:
+          terraform_version: ${{ inputs.terraform_version }}
+
+      - name: Terraform init
+        run: terraform init
+
+      - name: Terraform validate
+        run: terraform validate
+
+      - name: Terraform apply
+        run: terraform apply -var "docker_image_tag=${DOCKER_IMAGE_TAG}" -var-file=${ENV}.tfvars -auto-approve -input=false
+
+      - name: Wait for stabilization
+        run: aws ecs wait services-stable --cluster "main-${ENV}" --service "${SERVICE}"
+
+      - name: Notify success
+        uses: slackapi/slack-github-action@v1.23.0
+        with:
+          channel-id: ${{ inputs.slack_channel }}
+          slack-message: ":white_check_mark: A new version of `${{ inputs.service }}` (version `${{ inputs.docker_image_tag }}`) has been succseffuly deployed."
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+
+      - name: Notify failure
+        if: ${{ failure() }}
+        uses: slackapi/slack-github-action@v1.23.0
+        with:
+          channel-id: ${{ inputs.slack_channel }}
+          slack-message: ":rotating_siren: The last deployment of `${{ inputs.service }}` (version `${{ inputs.docker_image_tag }}`) has failed."
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Perform a terraform plan  against `preproduction` and `production` environment a
 ```yaml
 jobs:
   terraform:
-    uses: sencrop/github-workflows/.github/workflows/terraform-plan-v1.yml
+    uses: sencrop/github-workflows/.github/workflows/terraform-plan-v1.yml@master
     secrets: inherit
     with:
       terraform_version: "1.2.9"
@@ -23,19 +23,45 @@ The list of environment can be overrided using the `environment` variable.
       environments: "['preproduction']"
 ```
 
+If you need to use a private runner set `self_hosted` to `true`.
+
+```yaml
+    with:
+      self_hosted: true
+```
+
+
 ## terraform-plan-ecs
 
 This is a more specialized version of the terraform plan workflow dedicated to [standard ECS fargate service](https://github.com/sencrop/terraform-modules).  
-The main is that difference is that it will get the currrently deployed docker image tag version on aws and pass it to the plan.
+The main difference is that this workflow will fetch the currrently deployed docker image tag version on aws and pass it to the plan.
 
 
 ```yaml
 jobs:
   terraform:
-    uses: sencrop/github-workflows/.github/workflows/terraform-plan-ecs-v1.yml
+    uses: sencrop/github-workflows/.github/workflows/terraform-plan-ecs-v1.yml@master
     secrets: inherit
     with:
       service: "my-service"
       terraform_version: "1.2.9"
 
 ```
+
+## ecs-deploy
+
+This workflow will trigger a deployment of the given version of a [standard ECS fargate service](https://github.com/sencrop/terraform-modules).
+The outcome of the deployment will be notified on slack.
+
+
+```
+jobs:
+  deploy:
+    uses: sencrop/github-workflows/.github/workflows/ecs-deploy-v1.yml@master
+    secrets: inherit
+    with:
+      docker_image_tag: "tag-from-the-build-step"
+      environment: "preproduction pr production"
+      terraform_version: "1.2.9"
+      service: "my-service"
+      slack_channel: "my-ops-slack-channel"


### PR DESCRIPTION
This new workflow is a factorisation of the standard deployment of our ecs applications through terraform.

This PR also adds two new feature to that workflow:

- The workflow will wait until the deployment has been completed 
- The workflow will notify the outcome of the deployment to a slack channel


<img width="1021" alt="image" src="https://user-images.githubusercontent.com/779844/198971898-60642dd4-9409-4efd-9c58-c3a8d07c62b8.png">

<img width="773" alt="image" src="https://user-images.githubusercontent.com/779844/198972029-44673729-08cb-46b3-88c8-5c4438fd5e8f.png">

