### PR TITLE
feat: add databricks secrets as env variables

### DIFF
--- a/.github/workflows/terraform-apply-v1.yml
+++ b/.github/workflows/terraform-apply-v1.yml
@@ -39,6 +39,9 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       TF_WORKSPACE: ${{ inputs.environment }}
       TF_LOG: INFO
+      DATABRICKS_USERNAME: ${{ secrets.DATABRICKS_USERNAME }}
+      DATABRICKS_ACCOUNT_ID: ${{ secrets.DATABRICKS_ACCOUNT_ID }}
+      TF_VAR_databricks_account_id: ${{ secrets.DATABRICKS_ACCOUNT_ID }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/terraform-apply-v1.yml
+++ b/.github/workflows/terraform-apply-v1.yml
@@ -42,6 +42,8 @@ jobs:
       DATABRICKS_USERNAME: ${{ secrets.DATABRICKS_USERNAME }}
       DATABRICKS_ACCOUNT_ID: ${{ secrets.DATABRICKS_ACCOUNT_ID }}
       TF_VAR_databricks_account_id: ${{ secrets.DATABRICKS_ACCOUNT_ID }}
+      DATABRICKS_HOST: ${{ secrets.DATABRICKS_HOST }}
+      DATABRICKS_TOKEN: ${{ secrets.DATABRICKS_TOKEN }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/terraform-plan-v1.yml
+++ b/.github/workflows/terraform-plan-v1.yml
@@ -44,6 +44,9 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       TF_WORKSPACE: ${{ matrix.environment }}
       TF_LOG: INFO
+      DATABRICKS_USERNAME: ${{ secrets.DATABRICKS_USERNAME }}
+      DATABRICKS_ACCOUNT_ID: ${{ secrets.DATABRICKS_ACCOUNT_ID }}
+      TF_VAR_databricks_account_id: ${{ secrets.DATABRICKS_ACCOUNT_ID }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/terraform-plan-v1.yml
+++ b/.github/workflows/terraform-plan-v1.yml
@@ -47,6 +47,8 @@ jobs:
       DATABRICKS_USERNAME: ${{ secrets.DATABRICKS_USERNAME }}
       DATABRICKS_ACCOUNT_ID: ${{ secrets.DATABRICKS_ACCOUNT_ID }}
       TF_VAR_databricks_account_id: ${{ secrets.DATABRICKS_ACCOUNT_ID }}
+      DATABRICKS_HOST: ${{ secrets.DATABRICKS_HOST }}
+      DATABRICKS_TOKEN: ${{ secrets.DATABRICKS_TOKEN }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
Adding secrets to enable hephaistos terraforming databricks (linked to : https://github.com/sencrop/hephaistos/pull/92)

Some secrets have to be added at org level (cc @mdespriee ) : 
* `DATABRICKS_USERNAME`
* `DATABRICKS_ACCOUNT_ID`
* `DATABRICKS_HOST` (by default WeatherPlatform workspace, can be overriden at repository level if necessary)
* `DATABRICKS_TOKEN` (by default WeatherPlatform workspace, can be overriden at repository level if necessary)

Values for all fields can be found in Bitwarden, `databricks-admin @ Databricks` card.