### PR TITLE
Remove all backticks in generated plans before rendering it in a comment with github-script

### DIFF
--- a/.github/workflows/terraform-plan-ecs-v1.yml
+++ b/.github/workflows/terraform-plan-ecs-v1.yml
@@ -94,10 +94,10 @@ jobs:
           fi
 
       # Some plans may rarely contain backticks which break the following javascript code to create a comment and
-      # show the plan, so we need to remove them first
+      # show the plan, so we need to escape them first
       - name: Put Plan in Env Var
         run: |
-          sed 's/`//g' plan.txt > safe_plan.txt
+          sed 's|`|\\\`|g' plan.txt > safe_plan.txt
           PLAN=$(cat safe_plan.txt)
           echo "PLAN<<EOF" >> $GITHUB_ENV
           echo "$PLAN" >> $GITHUB_ENV

--- a/.github/workflows/terraform-plan-ecs-v2.yml
+++ b/.github/workflows/terraform-plan-ecs-v2.yml
@@ -109,7 +109,7 @@ jobs:
       # show the plan, so we need to remove them first
       - name: Put Plan in Env Var
         run: |
-          sed 's/`//g' plan.txt > safe_plan.txt
+          sed 's|`|\\\`|g' plan.txt > safe_plan.txt
           PLAN=$(cat safe_plan.txt)
           echo "PLAN<<EOF" >> $GITHUB_ENV
           echo "$PLAN" >> $GITHUB_ENV

--- a/.github/workflows/terraform-plan-v1.yml
+++ b/.github/workflows/terraform-plan-v1.yml
@@ -82,7 +82,7 @@ jobs:
       # show the plan, so we need to remove them first
       - name: Put Plan in Env Var
         run: |
-          sed 's/`//g' plan.txt > safe_plan.txt
+          sed 's|`|\\\`|g' plan.txt > safe_plan.txt
           PLAN=$(cat safe_plan.txt)
           echo "PLAN<<EOF" >> $GITHUB_ENV
           echo "$PLAN" >> $GITHUB_ENV

--- a/.github/workflows/terraform-plan-v2.yml
+++ b/.github/workflows/terraform-plan-v2.yml
@@ -94,7 +94,7 @@ jobs:
       # show the plan, so we need to remove them first
       - name: Put Plan in Env Var
         run: |
-          sed 's/`//g' plan.txt > safe_plan.txt
+          sed 's|`|\\\`|g' plan.txt > safe_plan.txt
           PLAN=$(cat safe_plan.txt)
           echo "PLAN<<EOF" >> $GITHUB_ENV
           echo "$PLAN" >> $GITHUB_ENV


### PR DESCRIPTION
In this pull request, I've noticed plans were breaking and it was due to a rare occurence of plans containing a backtick `

This broke the templated javascript code where it terminated the plan text string early. In order to remove this issue, I've added a little replacement to ensure we escape all backticks in the plan
https://github.com/sencrop/sencrop-mysql-management/pull/8

After escaping, the plan shows exactly as it was generated as shown in the PR linked above.

I've fixed it in all plan actions so that we should be safe from the issue if it happens in anywhere else.