### PR TITLE
feat: add a workflow to standardize version compute

### DIFF
--- a/.github/workflows/version-v2.yml
+++ b/.github/workflows/version-v2.yml
@@ -1,0 +1,36 @@
+---
+name: Find the version of the current build
+
+on:
+  workflow_call:
+    inputs:
+      use_tags:
+        type: boolean
+        default: false
+        description: if true the version will be extracted from the most recent tag value
+    outputs:
+      version:
+        value: ${{ jobs.version.outputs.version }}
+
+jobs:
+  version:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.git_hash.outputs.REF || steps.git_tags.outputs.REF }}
+    steps:
+      - name: checkout
+        uses: actions/checkout@v3
+
+      - name: Get version from git hash
+        if: "! inputs.use_tags"
+        id: git_hash
+        run: |
+          REF=$(git rev-parse --short HEAD)
+          echo "REF=$REF" >> ${GITHUB_OUTPUT}
+
+      - name: Get version from tags
+        if: inputs.use_tags
+        id: git_tags
+        run: |
+          REF=${GITHUB_REF#refs/tags/}
+          echo "REF=$REF" >> ${GITHUB_OUTPUT}

--- a/README.md
+++ b/README.md
@@ -58,6 +58,23 @@ jobs:
 
 ```
 
+### version
+
+This workflow will output a version for the current build. It can be either based on the commit hash (default) or on the current tag.  
+You can the get use the computed version in subsequent jobs using `${{ needs.version.outputs.version }}`.
+
+```yaml
+jobs:
+  version:
+    uses: sencrop/github-workflows/.github/workflows/version-v2.yml@master
+```
+
+If you want a versiom based on the current tag set `use_tags`.
+```yaml
+    with:
+      use_tags: true
+```
+
 ### docker-push
 
 This workflow build and push a docker image to an elastic container repository.
@@ -74,7 +91,7 @@ jobs:
 
 If you build often your docker image you might benefit from the built in [cache management](https://docs.docker.com/build/ci/github-actions/cache/).
 
-```
+```yaml
     with:
       cache_docker_layers: true
 ```


### PR DESCRIPTION
This workflow provides a standard version of the version computing so we can replace this:

```
  version:
    runs-on: ubuntu-latest
    outputs:
      docker_image_tag: ${{ steps.compute_ref.outputs.REF }}
    steps:
      - name: checkout
        uses: actions/checkout@v3

      - name: Get commit hash
        id: compute_ref
        run: |
          REF=${GITHUB_REF#refs/tags/}
          echo "REF=$REF" >> ${GITHUB_OUTPUT}
```

by this

```
  version:
    uses: sencrop/github-workflows/.github/workflows/version-v2.yml@master
```