### PR TITLE
feat: add deployment tracking action

### DIFF
--- a/.github/workflows/ecs-deploy-v2.yml
+++ b/.github/workflows/ecs-deploy-v2.yml
@@ -64,6 +64,7 @@ jobs:
       TF_WORKSPACE: ${{ inputs.environment }}
       TF_LOG: ${{ inputs.log_level }}
     permissions:
+      actions: write
       id-token: write
       contents: read
     steps:
@@ -111,13 +112,14 @@ jobs:
           echo "image_tag=$CURRENT_IMAGE_TAG" >> $GITHUB_OUTPUT
 
       - name: Notify deployment in progress
-        if: inputs.environment  == 'production'
-        uses: slackapi/slack-github-action@v1.23.0
+        uses: sencrop/github-workflows/actions/notify-deployment-in-progress@master
         with:
-          channel-id: deployment-updates-prod
-          slack-message: ":ship: New deployment of `${{ inputs.service }}` (version `${{ inputs.docker_image_tag }}`) in progress (<${{ env.GITHUB_REPOSITORY_URL }}/compare/${{ steps.current_version.outputs.image_tag }}...${{ inputs.docker_image_tag }}|CHANGELOG>)"
-        env:
-          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+          service: ${{ inputs.service }}
+          environment: ${{ inputs.environment }}
+          dd_api_key: ${{ secrets.DD_API_KEY }}
+          current_version: ${{ steps.current_version.outputs.image_tag }}
+          deployed_version: ${{ inputs.docker_image_tag }}
+          slack_bot_token: ${{ secrets.SLACK_BOT_TOKEN }}
 
       - name: Terraform apply
         run: terraform apply -var "docker_image_tag=${DOCKER_IMAGE_TAG}" -var-file=${ENV}.tfvars -auto-approve -input=false ${EXTRA_ARGS}
@@ -131,6 +133,13 @@ jobs:
             echo "You should check the logs to understand what happened: ${LOGS_URL}"
             exit 1
           fi
+
+      - name: Track deployment time
+        uses: sencrop/github-workflows/actions/track-deployment-time@master
+        with:
+          service: ${{ inputs.service }}
+          environment: ${{ inputs.environment }}
+          dd_api_key: ${{ secrets.DD_API_KEY }}
 
       - name: Notify success
         if: ${{ inputs.notify_on_success }}

--- a/README.md
+++ b/README.md
@@ -200,3 +200,52 @@ jobs:
     with:
       db_instance: my-instance-name
 ```
+
+## Standard actions
+
+### configure-aws-credentials
+
+This action will authenticate the current CI wokrflow with AWS 
+
+```yaml
+jobs:
+  my-job:
+    steps:
+      - name: Configure aws credentials
+        uses: sencrop/github-workflows/actions/configure-aws-credentials@master
+        with:
+          aws_account_id: ${{ vars.AWS_ACCOUNT_ID }}
+```
+
+### notify-deployment-in-progress
+This action will notify in slack and in datadog that a deployment has been initiated for an application.
+
+```yaml
+jobs:
+  my-job:
+    steps:
+      - name: Notify deployment in progress
+        uses: sencrop/github-workflows/actions/notify-deployment-in-progress@master
+        with:
+          service: my-service
+          environment: preproduction or production
+          dd_api_key: ${{ secrets.DD_API_KEY }}
+          current_version: version N-1
+          deployed_version: version N
+          slack_bot_token: ${{ secrets.SLACK_BOT_TOKEN }}
+```
+
+### track-deployment-time
+This action will track in datadog the deployment time based on the duration the Github Action workflow
+```
+jobs:
+  my-job:
+    steps:
+      - name: Track deployment time
+        uses: sencrop/github-workflows/actions/track-deployment-time@master
+        with:
+          service: my-service
+          environment: preproduction or production
+          dd_api_key: ${{ secrets.DD_API_KEY }}
+```
+

--- a/actions/notify-deployment-in-progress/action.yaml
+++ b/actions/notify-deployment-in-progress/action.yaml
@@ -1,0 +1,65 @@
+---
+name: "Track deployment"
+description: "Track a deployment in progress"
+
+inputs:
+  current_version:
+    type: string
+    required: true
+  dd_api_key:
+    type: string
+    required: true
+  deployed_version:
+    type: string
+    required: true
+  environment:
+    type: string
+    required: true
+  service:
+    type: string
+    required: true
+  slack_bot_token:
+    type: string
+  slack_channel:
+    type: string
+    default: "deployment-updates-prod"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Notify deployment in progress on slack
+      uses: slackapi/slack-github-action@v1.24.0
+      if: inputs.environment == 'production'
+      with:
+        channel-id: ${{ inputs.slack_channel }}
+        slack-message: ":ship: New deployment of `${{ inputs.service }}` (version `${{ inputs.deployed_version }}`) in progress (<${{ github.server_url }}/${{ github.repository }}/compare/${{ inputs.current_version }}...${{ inputs.deployed_version }}|CHANGELOG>)"
+      env:
+        SLACK_BOT_TOKEN: ${{ inputs.SLACK_BOT_TOKEN }}
+
+    - name: Track deployment in progresss on datadog
+      run: |
+        curl --silent -X POST "https://api.datadoghq.eu/api/v1/events" \
+        -H "Accept: application/json" \
+        -H "Content-Type: application/json" \
+        -H "DD-API-KEY: ${DD_API_KEY}" \
+        -d @- << EOF
+        {
+          "title": "Deployment in progress on $SERVICE",
+          "text": "$MESSAGE",
+          "tags": [
+            "operation:deployment",
+            "repository:${{ github.repository }}",
+            "env:$ENV",
+            "environment:$ENV",
+            "application:$SERVICE",
+            "service:$SERVICE"
+          ]
+        }
+        EOF
+      shell: bash
+      env:
+        DD_API_KEY: ${{ inputs.DD_API_KEY }} 
+        ENV: ${{ inputs.environment }}
+        MESSAGE: ${{ inputs.service }} is being updated from version ${{ inputs.current_version }} to ${{ inputs.deployed_version }} on ${{ inputs.environment }}
+        REPOSITORY: ${{ github.repository }}
+        SERVICE: ${{ inputs.service }}

--- a/actions/track-deployment-time/action.yaml
+++ b/actions/track-deployment-time/action.yaml
@@ -1,0 +1,55 @@
+---
+name: "Track deployment time"
+description: "Track the deployment time"
+
+inputs:
+  environment:
+    type: string
+    required: true
+  service:
+    type: string
+    required: true
+  dd_api_key:
+    type: string
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: Track deployment in datadog
+      run: |
+        start_ts=$(date -d "$(gh api /repos/${{ github.repository }}/actions/runs/${{ github.run_id }} | jq -r .run_started_at)" +"%s")
+        now_ts=$(date +%s)
+        curl --silent -X POST "https://api.datadoghq.eu/api/v2/series" \
+          -H "Accept: application/json" \
+          -H "Content-Type: application/json" \
+          -H "DD-API-KEY: ${DD_API_KEY}" \
+          -d @- << EOF
+            {
+              "series": [
+                {
+                  "metric": "sencrop.ci.deployment_time",
+                  "type": 3,
+                  "points": [
+                    {
+                      "timestamp": ${now_ts},
+                      "value":  $(( now_ts - start_ts))
+                    }
+                  ],
+                  "tags": [
+                    "repository:${{ github.repository }}",
+                    "env:$ENV",
+                    "environment:$ENV",
+                    "application:$SERVICE",
+                    "service:$SERVICE"
+                  ]
+                }
+              ]
+            }
+        EOF
+      shell: bash
+      env:
+        DD_API_KEY: ${{ inputs.dd_api_key }}
+        ENV: ${{ inputs.environment }}
+        GH_TOKEN: ${{ github.token }}
+        SERVICE: ${{ inputs.service }}


### PR DESCRIPTION
This PR adds 2 custom actions to track deployments:

- `notify-deployment-in-progress` this action encapsulate the logic of notifying when a deployment is in progress on slack that already exists (this logic in currently duplicated in several non standard repos such as `infrastructure-sencrop`). In this PR we also add an event to Datadog so we can easily graph and correlate deployment events.
![image](https://github.com/sencrop/github-workflows/assets/779844/69688a07-45d7-4cef-8370-68764458f80a)

- `track-deployment-action`: this action reports to Datadog as a metric the deployment time of a service
