### PR TITLE
feat: add a retry tag on deployment time metric

### DIFF
--- a/actions/track-deployment-time/action.yaml
+++ b/actions/track-deployment-time/action.yaml
@@ -19,8 +19,10 @@ runs:
     - name: Track deployment in datadog
       run: |
         set -euo pipefail
-        start_ts=$(date -d "$(gh api /repos/${{ github.repository }}/actions/runs/${{ github.run_id }} | jq -r .run_started_at)" +"%s")
+        action_run="$(gh api /repos/${{ github.repository }}/actions/runs/${{ github.run_id }})"
+        start_ts=$(date -d "$(echo ${action_run} | jq -r .run_started_at)" +"%s")
         now_ts=$(date +%s)
+        is_retry=$(if [[ $(echo "${action_run}" | jq '.run_attempt') -gt 1 ]]; then echo "true";else echo "false";fi)
         curl --silent -X POST "https://api.datadoghq.eu/api/v2/series" \
           -H "Accept: application/json" \
           -H "Content-Type: application/json" \
@@ -42,7 +44,8 @@ runs:
                     "env:$ENV",
                     "environment:$ENV",
                     "application:$SERVICE",
-                    "service:$SERVICE"
+                    "service:$SERVICE",
+                    "is_retry:${is_retry}"
                   ]
                 }
               ]


### PR DESCRIPTION
retried pipeline are often faster because we only retry a subpart of the actions so it's useful to be able to filter them out from dashboards