### PR TITLE
add platforms option to docker push action

### DIFF
--- a/.github/workflows/docker-push-v2.yml
+++ b/.github/workflows/docker-push-v2.yml
@@ -22,6 +22,9 @@ on:
       docker_image_tag:
         type: string
         required: true
+      target_platforms:
+        type: string
+        default: local
       use_ssh:
         type: boolean
         default: false
@@ -86,6 +89,7 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
           ssh: ${{ steps.set_ssh.outputs.ssh }}
+          platforms: ${{ inputs.target_platforms }}
 
       - name: Build and push (without cache)
         if: ${{ ! inputs.cache_docker_layers }}


### PR DESCRIPTION
cf docker action doc: https://github.com/docker/build-push-action?tab=readme-ov-file#inputs

And docker doc for the values: https://docs.docker.com/engine/reference/commandline/buildx_build/#platform

Passing `local` as a default should match the behaviour where no flag is passed if I understood well