### PR TITLE
Add qemu setup to docker push action

### DIFF
--- a/.github/workflows/docker-push-v2.yml
+++ b/.github/workflows/docker-push-v2.yml
@@ -52,6 +52,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 

--- a/.github/workflows/docker-push-v2.yml
+++ b/.github/workflows/docker-push-v2.yml
@@ -53,6 +53,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up QEMU
+        if: ${{ inputs.target_platforms != 'local'}}
         uses: docker/setup-qemu-action@v2
 
       - name: Set up Docker Buildx


### PR DESCRIPTION
Based on errors in https://github.com/sencrop/sencrop-bali-api/actions/runs/7714240306/job/21026033336

I guess we need to setup QEMU as shown in the docs of the docker push action: https://github.com/docker/build-push-action?tab=readme-ov-file