### PR TITLE
[SENP-648] feat(ecs-deploy): improve consistency of workflows parameters

### DIFF
--- a/.github/workflows/ecs-deploy-v2.yml
+++ b/.github/workflows/ecs-deploy-v2.yml
@@ -63,7 +63,6 @@ jobs:
       CI_IAM_ROLE: ${{ inputs.ci_iam_role }}
       DOCKER_IMAGE_TAG: ${{ inputs.docker_image_tag }}
       ENV: ${{ inputs.environment }}
-      EXTRA_ARGS: ${{ inputs.extra_args }}
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       GITHUB_REPOSITORY_URL: ${{ github.server_url }}/${{ github.repository }}
       GITHUB_ACTIONS_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
@@ -141,7 +140,7 @@ jobs:
       - name: Terraform apply
         run: |
           # shellcheck disable=SC2086
-          terraform apply ${{ steps.tf_vars.outputs.docker_image_tag || steps.tf_vars_deprecated.outputs.docker_image_tag }} -var-file=${ENV}.tfvars -auto-approve -input=false ${EXTRA_ARGS}
+          terraform apply ${{ steps.tf_vars.outputs.docker_image_tag || steps.tf_vars_deprecated.outputs.docker_image_tag }} -var-file=${{ inputs.environment }}.tfvars -auto-approve -input=false ${{ inputs.extra_args }}
 
       - name: Wait for stabilization
         if: ${{ inputs.wait_for_stabilization }}

--- a/.github/workflows/ecs-deploy-v2.yml
+++ b/.github/workflows/ecs-deploy-v2.yml
@@ -12,7 +12,8 @@ on:
         default: ""
       docker_image_tag:
         type: string
-        required: true
+        required: false
+        description: "DEPRECATED: use version instead"
       environment:
         type: string
         required: true
@@ -35,6 +36,12 @@ on:
         type: string
         required: true
       terraform_version:
+        type: string
+        required: false
+      use_version_as_docker_image_tag:
+        type: boolean
+        default: true
+      version:
         type: string
         required: false
       wait_for_stabilization:
@@ -90,12 +97,19 @@ jobs:
       - name: Terraform validate
         run: terraform validate
 
-      - name: Get current version
-        id: current_version
+      - name: Get former version from ECS
+        if: inputs.docker_image_tag || inputs.use_version_as_docker_image_tag
+        id: ecs_lookup
         run: |
           CURRENT_TASK_DEFINITION="$(aws ecs list-task-definitions | jq --arg SERVICE "$SERVICE" --arg ENVIRONMENT "$ENV" -r -c '.taskDefinitionArns[] | select(contains($SERVICE + "-" + $ENVIRONMENT))')"
           CURRENT_IMAGE_TAG="$(aws ecs describe-task-definition --task-definition "$CURRENT_TASK_DEFINITION" | jq --arg SERVICE "$SERVICE" -r -c '.taskDefinition.containerDefinitions[] | select(.name == $SERVICE) | .image' | cut -d':' -f2)"
           echo "image_tag=$CURRENT_IMAGE_TAG" >> "$GITHUB_OUTPUT"
+
+
+      - name: Get former version from Git
+        id: git_hash
+        if: "! (inputs.docker_image_tag || inputs.use_version_as_docker_image_tag)"
+        uses: sencrop/github-workflows/actions/look-git-hash@master
 
       - name: Notify deployment in progress
         uses: sencrop/github-workflows/actions/notify-deployment-in-progress@master
@@ -103,14 +117,29 @@ jobs:
           service: ${{ inputs.service }}
           environment: ${{ inputs.environment }}
           dd_api_key: ${{ secrets.DD_API_KEY }}
-          current_version: ${{ steps.current_version.outputs.image_tag }}
-          deployed_version: ${{ inputs.docker_image_tag }}
+          former_version: ${{ steps.ecs_lookup.outputs.image_tag || steps.git_hash.output.previous }}
+          new_version: ${{ inputs.docker_image_tag || steps.git_hash.output.current }}
           slack_bot_token: ${{ secrets.SLACK_BOT_TOKEN }}
+
+      # TODO: remove this step once docker_image_tag has been removed
+      - name: Build tf_vars (using docker_image_tag)
+        if: inputs.docker_image_tag
+        id: tf_vars_deprecated
+        run: |
+          TF_VAR_DOCKER_IMAGE_TAG="-var docker_image_tag=${{ inputs.docker_image_tag }}"
+          echo "docker_image_tag=$TF_VAR_DOCKER_IMAGE_TAG" >> "$GITHUB_OUTPUT"
+
+      - name: Build tf_vars (using version)
+        if: "! inputs.docker_image_tag && inputs.use_version_as_docker_image_tag"
+        id: tf_vars
+        run: |
+          TF_VAR_DOCKER_IMAGE_TAG="-var docker_image_tag=${{ inputs.version }}"
+          echo "docker_image_tag=$TF_VAR_DOCKER_IMAGE_TAG" >> "$GITHUB_OUTPUT"
+
 
       - name: Terraform apply
         run: |
-          # shellcheck disable=SC2086
-          terraform apply -var "docker_image_tag=${DOCKER_IMAGE_TAG}" -var-file="${ENV}.tfvars" -auto-approve -input=false ${EXTRA_ARGS}
+          terraform apply ${{ steps.tf_vars.output.docker_image_tag || steps.tf_vars_deprecated.output.docker_image_tag }} -var-file ${ENV}.tfvars -auto-approve -input=false ${EXTRA_ARGS}
 
       - name: Wait for stabilization
         if: ${{ inputs.wait_for_stabilization }}

--- a/.github/workflows/ecs-deploy-v2.yml
+++ b/.github/workflows/ecs-deploy-v2.yml
@@ -41,6 +41,7 @@ on:
       use_version_as_docker_image_tag:
         type: boolean
         default: true
+        required: false
       version:
         type: string
         required: false
@@ -109,7 +110,7 @@ jobs:
       - name: Get former version from Git
         id: git_hash
         if: "! (inputs.docker_image_tag || inputs.use_version_as_docker_image_tag)"
-        uses: sencrop/github-workflows/actions/look-git-hash@master
+        uses: sencrop/github-workflows/actions/lookup-git-hash@master
 
       - name: Notify deployment in progress
         uses: sencrop/github-workflows/actions/notify-deployment-in-progress@master

--- a/.github/workflows/ecs-deploy-v2.yml
+++ b/.github/workflows/ecs-deploy-v2.yml
@@ -118,7 +118,7 @@ jobs:
           environment: ${{ inputs.environment }}
           dd_api_key: ${{ secrets.DD_API_KEY }}
           former_version: ${{ steps.ecs_lookup.outputs.image_tag || steps.git_hash.outputs.previous }}
-          new_version: ${{ inputs.docker_image_tag || steps.git_hash.outputs.current }}
+          new_version: ${{ inputs.docker_image_tag || inputs.version }}
           slack_bot_token: ${{ secrets.SLACK_BOT_TOKEN }}
 
       # TODO: remove this step once docker_image_tag has been removed

--- a/.github/workflows/ecs-deploy-v2.yml
+++ b/.github/workflows/ecs-deploy-v2.yml
@@ -117,8 +117,8 @@ jobs:
           service: ${{ inputs.service }}
           environment: ${{ inputs.environment }}
           dd_api_key: ${{ secrets.DD_API_KEY }}
-          former_version: ${{ steps.ecs_lookup.outputs.image_tag || steps.git_hash.output.previous }}
-          new_version: ${{ inputs.docker_image_tag || steps.git_hash.output.current }}
+          former_version: ${{ steps.ecs_lookup.outputs.image_tag || steps.git_hash.outputs.previous }}
+          new_version: ${{ inputs.docker_image_tag || steps.git_hash.outputs.current }}
           slack_bot_token: ${{ secrets.SLACK_BOT_TOKEN }}
 
       # TODO: remove this step once docker_image_tag has been removed
@@ -139,7 +139,8 @@ jobs:
 
       - name: Terraform apply
         run: |
-          terraform apply ${{ steps.tf_vars.output.docker_image_tag || steps.tf_vars_deprecated.output.docker_image_tag }} -var-file ${ENV}.tfvars -auto-approve -input=false ${EXTRA_ARGS}
+          # shellcheck disable=SC2086
+          terraform apply ${{ steps.tf_vars.outputs.docker_image_tag || steps.tf_vars_deprecated.outputs.docker_image_tag }} -var-file=${ENV}.tfvars -auto-approve -input=false ${EXTRA_ARGS}
 
       - name: Wait for stabilization
         if: ${{ inputs.wait_for_stabilization }}

--- a/README.md
+++ b/README.md
@@ -127,11 +127,13 @@ jobs:
     uses: sencrop/github-workflows/.github/workflows/ecs-deploy-v2.yml@master
     secrets: inherit
     with:
-      docker_image_tag: tag-from-the-build-step
+      version: some-version
       environment: "preproduction or production"
       service: my-service
       slack_channel: my-ops-slack-channel
 ```
+
+If your service uses a static docker image tag you may set the flag `use_version_as_docker_image_tag` to `false`.
 
 
 ### ecs-start

--- a/actions/lookup-git-hash/action.yaml
+++ b/actions/lookup-git-hash/action.yaml
@@ -1,0 +1,13 @@
+---
+name: "Lookup git hash"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Lookup Git hash
+      id: git_hash
+      run: |
+        REF="$(git rev-parse --short HEAD)"
+        PREVIOUS_REF="$(git rev-parse --short HEAD~1)"
+        echo "current=$REF" >> "${GITHUB_OUTPUT}"
+        echo "previous=$PREVIOUS_REF" >> "${GITHUB_OUTPUT}"

--- a/actions/lookup-git-hash/action.yaml
+++ b/actions/lookup-git-hash/action.yaml
@@ -4,7 +4,7 @@ name: "Lookup git hash"
 runs:
   using: "composite"
   steps:
-    - name: Lookup Git hash
+    - name: Lookup current and previous Git hash
       id: git_hash
       run: |
         REF="$(git rev-parse --short HEAD)"

--- a/actions/lookup-git-hash/action.yaml
+++ b/actions/lookup-git-hash/action.yaml
@@ -11,3 +11,4 @@ runs:
         PREVIOUS_REF="$(git rev-parse --short HEAD~1)"
         echo "current=$REF" >> "${GITHUB_OUTPUT}"
         echo "previous=$PREVIOUS_REF" >> "${GITHUB_OUTPUT}"
+      shell: bash

--- a/actions/lookup-git-tag/action.yaml
+++ b/actions/lookup-git-tag/action.yaml
@@ -1,0 +1,13 @@
+---
+name: "Lookup git tag"
+
+runs:
+  using: "composite"
+  steps:
+      - name: Get version from tags
+        id: git_tag
+        run: |
+          REF="${GITHUB_REF#refs/tags/}"
+          PREVIOUS_REF="$(git tag -l 'v*' --sort=-v:refname | head -n2 | tail -n1)"
+          echo "current=$REF" >> "${GITHUB_OUTPUT}"
+          echo "previous=$PREVIOUS_REF" >> "${GITHUB_OUTPUT}"

--- a/actions/lookup-git-tag/action.yaml
+++ b/actions/lookup-git-tag/action.yaml
@@ -11,3 +11,4 @@ runs:
           PREVIOUS_REF="$(git tag -l 'v*' --sort=-v:refname | head -n2 | tail -n1)"
           echo "current=$REF" >> "${GITHUB_OUTPUT}"
           echo "previous=$PREVIOUS_REF" >> "${GITHUB_OUTPUT}"
+      shell: bash

--- a/actions/lookup-git-tag/action.yaml
+++ b/actions/lookup-git-tag/action.yaml
@@ -4,11 +4,11 @@ name: "Lookup git tag"
 runs:
   using: "composite"
   steps:
-      - name: Get version from tags
-        id: git_tag
-        run: |
-          REF="${GITHUB_REF#refs/tags/}"
-          PREVIOUS_REF="$(git tag -l 'v*' --sort=-v:refname | head -n2 | tail -n1)"
-          echo "current=$REF" >> "${GITHUB_OUTPUT}"
-          echo "previous=$PREVIOUS_REF" >> "${GITHUB_OUTPUT}"
-      shell: bash
+    - name: Lookup current and previous Git tag
+      id: git_tag
+      run: |
+        REF="${GITHUB_REF#refs/tags/}"
+        PREVIOUS_REF="$(git tag -l 'v*' --sort=-v:refname | head -n2 | tail -n1)"
+        echo "current=$REF" >> "${GITHUB_OUTPUT}"
+        echo "previous=$PREVIOUS_REF" >> "${GITHUB_OUTPUT}"
+    shell: bash

--- a/actions/notify-deployment-in-progress/action.yaml
+++ b/actions/notify-deployment-in-progress/action.yaml
@@ -14,8 +14,6 @@ inputs:
     description: "DEPRECATED: use former_version instead"
   former_version:
     type: string
-  deployed_version:
-    type: string
   environment:
     type: string
     required: true

--- a/actions/notify-deployment-in-progress/action.yaml
+++ b/actions/notify-deployment-in-progress/action.yaml
@@ -5,16 +5,22 @@ description: "Track a deployment in progress"
 inputs:
   current_version:
     type: string
-    required: true
+    description: "DEPRECATED: use new_version instead"
   dd_api_key:
     type: string
     required: true
   deployed_version:
     type: string
-    required: true
+    description: "DEPRECATED: use former_version instead"
+  former_version:
+    type: string
+  deployed_version:
+    type: string
   environment:
     type: string
     required: true
+  new_version:
+    type: string
   service:
     type: string
     required: true
@@ -35,7 +41,7 @@ runs:
       if: inputs.environment == 'production' && inputs.slack_notify == 'true'
       with:
         channel-id: ${{ inputs.slack_channel }}
-        slack-message: ":ship: New deployment of `${{ inputs.service }}` (version `${{ inputs.deployed_version }}`) in progress (<${{ github.server_url }}/${{ github.repository }}/compare/${{ inputs.current_version }}...${{ inputs.deployed_version }}|CHANGELOG>)"
+        slack-message: ":ship: New deployment of `${{ inputs.service }}` (version `${{ inputs.new_version || inputs.deployed_version }}`) in progress (<${{ github.server_url }}/${{ github.repository }}/compare/${{ inputs.former_version || inputs.current_version }}...${{ inputs.new_version || inputs.deployed_version }}|CHANGELOG>)"
       env:
         SLACK_BOT_TOKEN: ${{ inputs.SLACK_BOT_TOKEN }}
 

--- a/actions/notify-deployment-in-progress/action.yaml
+++ b/actions/notify-deployment-in-progress/action.yaml
@@ -6,19 +6,23 @@ inputs:
   current_version:
     type: string
     description: "DEPRECATED: use new_version instead"
+    required: false
   dd_api_key:
     type: string
     required: true
   deployed_version:
     type: string
     description: "DEPRECATED: use former_version instead"
+    required: false
   former_version:
     type: string
+    required: false
   environment:
     type: string
     required: true
   new_version:
     type: string
+    required: false
   service:
     type: string
     required: true


### PR DESCRIPTION
**ecs-deploy**:
- `docker_image_tag` is now optional on the `ecs-deploy` deploy workflow, this will make applications that have a static image tag easier to configure.
- `docker_image_tag` is now deprecated in favour of `version`, this term is closer to the level of abstraction of this workflow.
- when using `version` one might set `use_version_as_docker_image_tag` to `false` to avoid the version being passed as docker_image_tag to the terraform apply (default is `true`, this is the most common usage)
 
 **deployment-notification**:
 - `current_version` is now deprecated in favour of `former_version` and `deployed_version` in favour of `new_version`, this should reduce the ambiguity when using this action.