### PR TITLE
feat(preview): remove application name from netlify preview alias

### DIFF
--- a/.github/workflows/netlify-deploy-preview-v1.yml
+++ b/.github/workflows/netlify-deploy-preview-v1.yml
@@ -60,7 +60,7 @@ jobs:
           production-deploy: false
           deploy-message: "Deploy from GitHub Actions"
           netlify-config-path: ./netlify.toml
-          alias: ${{ inputs.application }}-${{ inputs.environment }}-${{ github.event.number }}
+          alias: ${{ inputs.environment }}-${{ github.event.number }}
           enable-pull-request-comment: true
           overwrites-pull-request-comment: true
           enable-github-deployment: false


### PR DESCRIPTION
As it is unnecessary / redundant regarding the usage of custom subdomains with application name: 
- https://app-preview-staging-4963.app.preview.sencrop.com > https://staging-4963.app.preview.sencrop.com
- https://back-office-preview-staging-438.backoffice.preview.sencrop.com > https://staging-438.backoffice.preview.sencrop.com
