### PR TITLE
feat: add terraform-deploy workflows

### DIFF
--- a/.github/workflows/terraform-deploy-v1.yml
+++ b/.github/workflows/terraform-deploy-v1.yml
@@ -1,0 +1,157 @@
+---
+name: Deploy an application managed by terraform
+
+on:
+  workflow_call:
+    inputs:
+      application:
+        type: string
+        required: true
+      aws_region:
+        type: string
+        default: "eu-central-1"
+      ci_iam_role:
+        type: string
+        default: ""
+      environment:
+        type: string
+        required: true
+      extra_args:
+        type: string
+        default: ""
+      log_level:
+        type: string
+        default: "INFO"
+      notify_on_success:
+        type: boolean
+        default: false
+      self_hosted:
+        type: boolean
+        default: false
+      slack_channel:
+        type: string
+        required: false
+      terraform_version:
+        type: string
+        required: false
+      version:
+        type: string
+        required: false
+      working_directory:
+        type: string
+        default: "./infra/terraform"
+
+jobs:
+  deploy:
+    runs-on: ${{ inputs.self_hosted && fromJSON(format('["self-hosted","{0}"]', inputs.environment)) || 'ubuntu-latest' }}
+    environment: ${{ inputs.environment }}
+    defaults:
+      run:
+        working-directory: ${{ inputs.working_directory }}
+    env:
+      AWS_DEFAULT_REGION: ${{ inputs.aws_region }}
+      CI_IAM_ROLE: ${{ inputs.ci_iam_role }}
+      ENV: ${{ inputs.environment }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GITHUB_REPOSITORY_URL: ${{ github.server_url }}/${{ github.repository }}
+      GITHUB_ACTIONS_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+      APPLICATION_LOGS_URL: https://app.datadoghq.eu/logs?query=application%3A${{ inputs.application }}%20version%3A${{ inputs.version }}%20env%3A${{ inputs.environment }}
+      TF_WORKSPACE: ${{ inputs.environment }}
+      TF_LOG: ${{ inputs.log_level }}
+    permissions:
+      actions: write
+      id-token: write
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Validate production version format
+        if: ${{ inputs.environment == 'production' }}
+        run: |
+          echo "Validating that production version has a valid format (must be v{major}.{minor}.{patch})"
+          echo "${{ inputs.version }}" | grep -P '^v[0-9]+\.[0-9]+\.[0-9]+$'
+
+      - name: Find slack channel
+        if: ${{ inputs.slack_channel == '' }}
+        id: default_slack_channel
+        run: |
+          if [[ "$environment" == "production" ]]; then
+            echo "channel_id=ops" >> "$GITHUB_OUTPUT"
+          elif [[ "$environment" == "preproduction" ]]; then
+            echo "channel_id=ops-preprod" >> "$GITHUB_OUTPUT"
+          else
+            echo "unknown environment: $environment"
+            exit 1
+          fi
+        env:
+          environment: ${{ inputs.environment }}
+
+      - name: Configure aws credentials
+        uses: sencrop/github-workflows/actions/configure-aws-credentials@master
+        with:
+          aws_account_id: ${{ vars.AWS_ACCOUNT_ID }}
+          aws_region: ${{ inputs.aws_region }}
+          ci_iam_role: ${{ inputs.ci_iam_role }}
+
+      - name: Terraform setup
+        uses: sencrop/github-workflows/actions/setup-terraform@master
+        with:
+          terraform_version: ${{ inputs.terraform_version }}
+          working_directory: ${{ inputs.working_directory }}
+
+      - name: Terraform init
+        run: terraform init -input=false
+
+      - name: Lookup deployed version
+        uses: sencrop/github-workflows/actions/lookup-deployed-version@master
+        id: deployed_version
+        with:
+          environment: ${{ inputs.environment }}
+
+      - name: Notify deployment in progress
+        uses: sencrop/github-workflows/actions/notify-deployment-in-progress-v2@master
+        with:
+          application: ${{ inputs.application }}
+          environment: ${{ inputs.environment }}
+          dd_api_key: ${{ secrets.DD_API_KEY }}
+          former_version: ${{ steps.deployed_version.outputs.version }}
+          new_version: ${{ inputs.version }}
+          slack_bot_token: ${{ secrets.SLACK_BOT_TOKEN }}
+
+      - name: Add environment tag
+        uses: sencrop/github-workflows/actions/add-git-tag@master
+        with:
+          tag: ${{ inputs.environment }}
+
+      - name: Terraform apply
+        run: |
+          # shellcheck disable=SC2086
+          terraform apply -var-file=${{ inputs.environment }}.tfvars -auto-approve -input=false ${{ inputs.extra_args }}
+
+      - name: Track deployment time
+        uses: sencrop/github-workflows/actions/track-deployment-time-v2@master
+        with:
+          application: ${{ inputs.application }}
+          environment: ${{ inputs.environment }}
+          dd_api_key: ${{ secrets.DD_API_KEY }}
+
+      - name: Notify success
+        if: ${{ inputs.notify_on_success }}
+        uses: slackapi/slack-github-action@v1.25.0
+        with:
+          channel-id: ${{ inputs.slack_channel || steps.default_slack_channel.outputs.channel_id }}
+          slack-message: ":white_check_mark: A new version of `${{ inputs.application }}` (version `${{ inputs.version }}`) has been successfully deployed to ${{ inputs.environment }} (<${{ env.GITHUB_ACTIONS_URL }}|Github Actions>|<${{ env.APPLICATION_LOGS_URL }}|Logs>)."
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+
+      - name: Notify failure
+        if: ${{ failure() }}
+        uses: slackapi/slack-github-action@v1.25.0
+        with:
+          channel-id: ${{ inputs.slack_channel || steps.default_slack_channel.outputs.channel_id }}
+          slack-message: ":rotating_siren: The last deployment of `${{ inputs.application }}` (version `${{ inputs.version }}`) to ${{ inputs.environment }} has failed (<${{ env.GITHUB_ACTIONS_URL }}|Github Actions>|<${{ env.APPLICATION_LOGS_URL }}|Logs>)."
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}


### PR DESCRIPTION
This workflow has a higher abstraction level than terraform apply. It should be used to deploy application that are managed by terraform but are not ECS applications.