### PR TITLE
fix(ecs-deploy): remove version format validation from ecs-deploy-v2

### DIFF
--- a/.github/workflows/ecs-deploy-v2.yml
+++ b/.github/workflows/ecs-deploy-v2.yml
@@ -74,12 +74,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Validate production version format
-        if: ${{ inputs.environment == 'production' }}
-        run: |
-          echo "Validating that production version has a valid format (must be v{major}.{minor}.{patch})"
-          echo "${{ inputs.version }}" | grep -P '^v[0-9]+\.[0-9]+\.[0-9]+$'
-
       - name: Find slack channel
         if: ${{ inputs.slack_channel == '' }}
         id: default_slack_channel


### PR DESCRIPTION
Some application such as `intake-stats` don't use yet a `v*` version.
As application that requires this validation have been migrated to ecs-deploy-v3 we can remove this check from the v2 version while are migrating the rest of the repositories to the standard release.