### PR TITLE
feat(release-please): add support for continuous release

### DIFF
--- a/.github/workflows/release-please-v1.yml
+++ b/.github/workflows/release-please-v1.yml
@@ -1,8 +1,14 @@
 ---
-name: Manage releases using release-please
+name: Manage releases
 
 on:
   workflow_call:
+    inputs:
+      create_pull_request:
+        type: boolean
+        default: true
+        description: if true the workflow will create a release PR otherwise a github release is directly created
+
     outputs:
       pr_created:
         value: ${{ jobs.release-please.outputs.prs_created }}
@@ -22,6 +28,9 @@ jobs:
       contents: write
       pull-requests: write
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
       # from https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app
       - name: Get app token
         id: app_token
@@ -81,9 +90,59 @@ jobs:
           echo "token=$token" >> "$GITHUB_OUTPUT"
 
       - name: Run release-please
+        if: inputs.create_pull_request
         id: release_please
         uses: googleapis/release-please-action@v4
         with:
           token: ${{ steps.app_token.outputs.token }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+
+      - name: Write .releaserc
+        if: "! inputs.create_pull_request"
+        run: |
+          echo '{
+            "plugins": [
+              [
+                "@semantic-release/commit-analyzer",
+                {
+                  "releaseRules": [
+                    { "type": "feat", "release": "minor" },
+                    { "type": "fix", "release": "patch" },
+                    { "type": "refactor", "release": "patch" },
+                    { "type": "chore", "release": "patch" },
+                    { "type": "docs", "release": "patch" },
+                    { "type": "deps", "release": "patch" },
+                    { "type": "ci", "release": "patch" },
+                    { "type": "perf", "release": "patch" },
+                    { "type": "build", "release": "patch" },
+                    { "type": "style", "release": "patch" },
+                    { "type": "test", "release": "patch" }
+                  ]
+                }
+              ],
+              [
+                "@semantic-release/release-notes-generator",
+                {
+                  "preset": "conventionalcommits",
+                  "presetConfig": {
+                    "types": [
+                      { "type": "feat", "section": "New features", "hidden": false },
+                      { "type": "fix", "section": "Bug fixes", "hidden": false },
+                      { "type": "chore", "section": "Miscellaneous Chores", "hidden": false }
+                    ]
+                  }
+                }
+              ],
+              "@semantic-release/github"
+            ]
+          }' > .releaserc
+
+      - name: Create github release only
+        if: "! inputs.create_pull_request"
+        uses: cycjimmy/semantic-release-action@v4
+        with:
+          extra_plugins: |
+            conventional-changelog-conventionalcommits@6.0.0
+        env:
+          GITHUB_TOKEN: ${{ steps.app_token.outputs.token }}


### PR DESCRIPTION
Some repositories don't have a preproduction environment and release continuously every merge to master.
Using the release-please PR on this repositories would be a step back as release would take one additional step.

With this pull request we introduce the `use_release_pr` flag, when set to false the release will be created directly without going through a pull request.

Note that this was not possible with release-please by itself as it must create a pull request: https://github.com/googleapis/release-please/issues/1696. We use `semantic-release-action` instead which is likely what release-please use under the hood.
 