### PR TITLE
perf(upload-artifact): archive and compress artifact directory

### DIFF
--- a/actions/download-artifact/action.yaml
+++ b/actions/download-artifact/action.yaml
@@ -16,5 +16,7 @@ runs:
   steps:
     - name: Download build output
       run: |
-        aws s3 sync s3://${{ inputs.s3_bucket }}/${{ inputs.application }}/${{ inputs.version }} ${{ inputs.local_dir }} --only-show-errors
+        aws s3 cp s3://${{ inputs.s3_bucket }}/${{ inputs.application }}/${{ inputs.version }}/artifact.tar.gz .
+        tar xzvf artifact.tar.gz ${{ inputs.local_dir }}
+        rm artifact.tar.gz
       shell: bash

--- a/actions/upload-artifact/action.yaml
+++ b/actions/upload-artifact/action.yaml
@@ -16,5 +16,7 @@ runs:
   steps:
     - name: Upload build output
       run: |
-        aws s3 sync ${{ inputs.local_dir }} s3://${{ inputs.s3_bucket }}/${{ inputs.application }}/${{ inputs.version }} --only-show-errors
+        tar czvf artifact.tar.gz ${{ inputs.local_dir }}
+        aws s3 cp artifact.tar.gz s3://${{ inputs.s3_bucket }}/${{ inputs.application }}/${{ inputs.version }}/artifact.tar.gz
+        rm artifact.tar.gz
       shell: bash


### PR DESCRIPTION
This change should mostly improve the s3 costs performances and later make the clean up easier.

Why ?
The most expensive operation is s3 are Tier1 requests (POST, PUT etc..). Using `aws s3 sync` is handy but under the hood it makes 1 api call per object. So when we sync the build of directory of some apps we end up doing thousands of Tier-1 operations. This also makes the further clean up as this needs to performed object per object.