### PR TITLE
fix(experimental): add a prefix to experimental build version

### DIFF
--- a/.github/workflows/docker-experiment-v1.yml
+++ b/.github/workflows/docker-experiment-v1.yml
@@ -17,7 +17,7 @@ jobs:
     with:
       cache_docker_layers: true
       image_name: ${{ inputs.image_name }}
-      image_tag: ${{ github.run_id }}
+      image_tag: x${{ github.run_id }}
 
   comment:
     runs-on: ${{ inputs.runs_on }}
@@ -40,7 +40,7 @@ jobs:
               return comment.user.type === 'Bot' && comment.body.includes(commentTitle)
             })
             const output = `#### ${commentTitle}
-              Build ID: ${{ github.run_id }}
+              Build ID: x${{ github.run_id }}
               [Deploy this version](${{ github.server_url }}/${{ github.repository }}/actions/workflows/deploy.yml)
             `
             // Update a comment if it already exists

--- a/.github/workflows/ecs-deploy-v3.yml
+++ b/.github/workflows/ecs-deploy-v3.yml
@@ -85,8 +85,8 @@ jobs:
       - name: Validate production version format
         if: ${{ inputs.validate_production_version && inputs.environment == 'production' }}
         run: |
-          echo "Validating that production version has a valid format (must be v{major}.{minor}.{patch})"
-          echo "${{ inputs.version }}" | grep -P '^v[0-9]+\.[0-9]+\.[0-9]+$'
+          echo "Validating that production version has a valid format (must be v{major}.{minor}.{patch} or x{build id})"
+          echo "${{ inputs.version }}" | grep -P '^(v[0-9]+\.[0-9]+\.[0-9]+)|(x[0-9]+)$'
 
       - name: Find slack channel
         if: ${{ inputs.slack_channel == '' }}


### PR DESCRIPTION
Experimental build will have the `x` prefix e.g. `x1234330`. Having a dedicated prefix allow to apply different rules for experimental build, such as deploy to prod in this pull request.