### PR TITLE
chore: add env tag for base branch only

### DIFF
--- a/.github/workflows/ecs-deploy-v3.yml
+++ b/.github/workflows/ecs-deploy-v3.yml
@@ -143,6 +143,7 @@ jobs:
           echo "docker_image_tag=$TF_VAR_DOCKER_IMAGE_TAG" >> "$GITHUB_OUTPUT"
 
       - name: Add environment tag
+        if: github.ref_name == 'master'
         uses: sencrop/github-workflows/actions/add-git-tag@master
         with:
           tag: ${{ inputs.environment }}

--- a/.github/workflows/terraform-deploy-v1.yml
+++ b/.github/workflows/terraform-deploy-v1.yml
@@ -125,6 +125,7 @@ jobs:
           slack_bot_token: ${{ secrets.SLACK_BOT_TOKEN }}
 
       - name: Add environment tag
+        if: github.ref_name == 'master'
         uses: sencrop/github-workflows/actions/add-git-tag@master
         with:
           tag: ${{ inputs.environment }}


### PR DESCRIPTION
Follow up of slack issue https://sencrop.slack.com/archives/C046SM8RVFD/p1728372180545099

We need to prevent moving the "environment" tag to the branch being ran with experiment flow as it won't be reachable from the base branch later on.