### PR TITLE
chore(node-modules-cache): add architecture to cache key

### DIFF
--- a/.github/workflows/node-module-cache-v1.yml
+++ b/.github/workflows/node-module-cache-v1.yml
@@ -38,4 +38,4 @@ jobs:
         uses: actions/cache/save@v4
         with:
           path: "**/node_modules"
-          key: ${{ runner.os }}-npm-${{ hashFiles('package-lock.json') }}
+          key: ${{ runner.os }}-${{ runner.arch }}-npm-${{ hashFiles('package-lock.json') }}

--- a/actions/npm-ci-with-cache/action.yaml
+++ b/actions/npm-ci-with-cache/action.yaml
@@ -21,8 +21,8 @@ runs:
       id: restore-cache
       with:
         path: "**/node_modules"
-        key: ${{ runner.os }}-npm-${{ hashFiles('package-lock.json') }}
-        restore-keys: ${{ runner.os }}-npm-
+        key: ${{ runner.os }}-${{ runner.arch }}-npm-${{ hashFiles('package-lock.json') }}
+        restore-keys: ${{ runner.os }}-${{ runner.arch }}-npm-
 
     - name: Set authToken for npm
       if: steps.restore-cache.outputs.cache-hit != 'true'


### PR DESCRIPTION
This PR adds the cpu architecture to the cache key. Some libraries (e.g. `esbuild`) are compiled for the target cpu architecture so we can't share the same cache between runners with different architecture.