### PR TITLE
Revert "chore: use arm64 as default for node-module-cache"

### DIFF
--- a/.github/workflows/node-module-cache-v1.yml
+++ b/.github/workflows/node-module-cache-v1.yml
@@ -14,7 +14,7 @@ on:
         description: Enable --ignore-scripts option
       runs_on:
         type: string
-        default: ubuntu-latest-arm64
+        default: ubuntu-latest
 
 jobs:
   update_cache:


### PR DESCRIPTION
Reverts sencrop/github-workflows#169