### PR TITLE
chore(docker-tag): do not fail if tag already exists

### DIFF
--- a/.github/workflows/docker-tag-v1.yml
+++ b/.github/workflows/docker-tag-v1.yml
@@ -70,7 +70,7 @@ jobs:
 
       - name: Tag image
         run: |
-          IMAGE_EXISTS=$(aws ecr describe-images --repository-name ${{ inputs.image_name }} --image-ids imageTag=${{ inputs.image_tag_to}})
+          IMAGE_EXISTS=$(aws ecr describe-images --repository-name ${{ inputs.image_name }} --image-ids imageTag=${{ inputs.image_tag_to }} 2>/dev/null)
           if [[ -z "$IMAGE_EXISTS" ]]; then
             MANIFEST=$(aws ecr batch-get-image --repository-name ${{ inputs.image_name }} --image-ids imageTag=${{ inputs.image_tag_from }} --output text --query 'images[].imageManifest')
             aws ecr put-image --repository-name ${{ inputs.image_name }} --image-tag ${{ inputs.image_tag_to }} --image-manifest "$MANIFEST"

--- a/.github/workflows/docker-tag-v1.yml
+++ b/.github/workflows/docker-tag-v1.yml
@@ -75,5 +75,5 @@ jobs:
             MANIFEST=$(aws ecr batch-get-image --repository-name ${{ inputs.image_name }} --image-ids imageTag=${{ inputs.image_tag_from }} --output text --query 'images[].imageManifest')
             aws ecr put-image --repository-name ${{ inputs.image_name }} --image-tag ${{ inputs.image_tag_to }} --image-manifest "$MANIFEST"
           else
-            echo "image ${{ inputs.image_name }}" tag ${{ inputs.image_tag_to }} already exists. Skipping..."
+            echo "image ${{ inputs.image_name }} tag ${{ inputs.image_tag_to }} already exists. Skipping..."
           fi

--- a/.github/workflows/docker-tag-v1.yml
+++ b/.github/workflows/docker-tag-v1.yml
@@ -70,5 +70,10 @@ jobs:
 
       - name: Tag image
         run: |
-          MANIFEST=$(aws ecr batch-get-image --repository-name ${{ inputs.image_name }} --image-ids imageTag=${{ inputs.image_tag_from }} --output text --query 'images[].imageManifest')
-          aws ecr put-image --repository-name ${{ inputs.image_name }} --image-tag ${{ inputs.image_tag_to}} --image-manifest "$MANIFEST"
+          IMAGE_EXISTS=$(aws ecr describe-images --repository-name ${{ inputs.image_name }} --image-ids imageTag=${{ inputs.image_tag_to}})
+          if [[ -z "$IMAGE_EXISTS" ]]; then
+            MANIFEST=$(aws ecr batch-get-image --repository-name ${{ inputs.image_name }} --image-ids imageTag=${{ inputs.image_tag_from }} --output text --query 'images[].imageManifest')
+            aws ecr put-image --repository-name ${{ inputs.image_name }} --image-tag ${{ inputs.image_tag_to }} --image-manifest "$MANIFEST"
+          else
+            echo "image ${{ inputs.image_name }}" tag ${{ inputs.image_tag_to }} already exists. Skipping..."
+          fi


### PR DESCRIPTION
Same as the previous PR but with an addition to better handle the error. I had a bit of a different behaviour when testing it locally and didn't have it crashing but piping the error to `/dev/null` should fix it hopefully.