### PR TITLE
chore(docker-tag): do not fail if tag already exists - v3

### DIFF
--- a/.github/workflows/docker-tag-v1.yml
+++ b/.github/workflows/docker-tag-v1.yml
@@ -70,7 +70,7 @@ jobs:
 
       - name: Tag image
         run: |
-          IMAGE_EXISTS=$(aws ecr describe-images --repository-name ${{ inputs.image_name }} --image-ids imageTag=${{ inputs.image_tag_to}})
+          IMAGE_EXISTS=$(aws ecr describe-images --repository-name ${{ inputs.image_name }} --image-ids imageTag=${{ inputs.image_tag_to }} 2>/dev/null)
           if [[ -z "$IMAGE_EXISTS" ]]; then
             MANIFEST=$(aws ecr batch-get-image --repository-name ${{ inputs.image_name }} --image-ids imageTag=${{ inputs.image_tag_from }} --output text --query 'images[].imageManifest')
             aws ecr put-image --repository-name ${{ inputs.image_name }} --image-tag ${{ inputs.image_tag_to }} --image-manifest "$MANIFEST"

--- a/.github/workflows/docker-tag-v1.yml
+++ b/.github/workflows/docker-tag-v1.yml
@@ -75,5 +75,5 @@ jobs:
             MANIFEST=$(aws ecr batch-get-image --repository-name ${{ inputs.image_name }} --image-ids imageTag=${{ inputs.image_tag_from }} --output text --query 'images[].imageManifest')
             aws ecr put-image --repository-name ${{ inputs.image_name }} --image-tag ${{ inputs.image_tag_to }} --image-manifest "$MANIFEST"
           else
-            echo "image ${{ inputs.image_name }}" tag ${{ inputs.image_tag_to }} already exists. Skipping..."
+            echo "image ${{ inputs.image_name }} tag ${{ inputs.image_tag_to }} already exists. Skipping..."
           fi

--- a/.github/workflows/docker-tag-v1.yml
+++ b/.github/workflows/docker-tag-v1.yml
@@ -69,8 +69,8 @@ jobs:
           exit 1
 
       - name: Tag image
-        shell: bash {0}
         run: |
+          set +e
           IMAGE_EXISTS=$(aws ecr describe-images --repository-name ${{ inputs.image_name }} --image-ids imageTag=${{ inputs.image_tag_to }} 2>/dev/null)
           if [[ -z "$IMAGE_EXISTS" ]]; then
             MANIFEST=$(aws ecr batch-get-image --repository-name ${{ inputs.image_name }} --image-ids imageTag=${{ inputs.image_tag_from }} --output text --query 'images[].imageManifest')

--- a/.github/workflows/docker-tag-v1.yml
+++ b/.github/workflows/docker-tag-v1.yml
@@ -69,6 +69,7 @@ jobs:
           exit 1
 
       - name: Tag image
+        shell: bash {0}
         run: |
           IMAGE_EXISTS=$(aws ecr describe-images --repository-name ${{ inputs.image_name }} --image-ids imageTag=${{ inputs.image_tag_to }} 2>/dev/null)
           if [[ -z "$IMAGE_EXISTS" ]]; then

--- a/.github/workflows/docker-tag-v1.yml
+++ b/.github/workflows/docker-tag-v1.yml
@@ -70,5 +70,10 @@ jobs:
 
       - name: Tag image
         run: |
-          MANIFEST=$(aws ecr batch-get-image --repository-name ${{ inputs.image_name }} --image-ids imageTag=${{ inputs.image_tag_from }} --output text --query 'images[].imageManifest')
-          aws ecr put-image --repository-name ${{ inputs.image_name }} --image-tag ${{ inputs.image_tag_to}} --image-manifest "$MANIFEST"
+          IMAGE_EXISTS=$(aws ecr describe-images --repository-name ${{ inputs.image_name }} --image-ids imageTag=${{ inputs.image_tag_to}})
+          if [[ -z "$IMAGE_EXISTS" ]]; then
+            MANIFEST=$(aws ecr batch-get-image --repository-name ${{ inputs.image_name }} --image-ids imageTag=${{ inputs.image_tag_from }} --output text --query 'images[].imageManifest')
+            aws ecr put-image --repository-name ${{ inputs.image_name }} --image-tag ${{ inputs.image_tag_to }} --image-manifest "$MANIFEST"
+          else
+            echo "image ${{ inputs.image_name }}" tag ${{ inputs.image_tag_to }} already exists. Skipping..."
+          fi


### PR DESCRIPTION
Third try to make this change, github workflows actually sets `shell: bash -e {0}` by default cf [doc](https://github.com/sencrop/github-workflows/pull/176) which makes an intermediate command failure fail the entire script.

Setting `shell: bash {0}` to override the default should finally fix the issue.