### PR TITLE
fix(docker-build-push): disable provenance attestation

### DIFF
--- a/.github/workflows/docker-push-v4.yml
+++ b/.github/workflows/docker-push-v4.yml
@@ -91,6 +91,7 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
           ssh: ${{ steps.set_ssh.outputs.ssh }}
+          provenance: false
 
       - name: Build and push (without cache)
         if: ${{ ! inputs.cache_docker_layers }}
@@ -101,3 +102,4 @@ jobs:
           push: true
           tags: ${{ vars.AWS_ACCOUNT_ID }}.dkr.ecr.eu-central-1.amazonaws.com/${{ inputs.image_name }}:${{ inputs.image_tag }}
           ssh: ${{ steps.set_ssh.outputs.ssh }}
+          provenance: false


### PR DESCRIPTION
# Context
Currently images are generated with an image index set to `application/vnd.oci.image.index.v1+json` which is unsupported for some use-cases like containers for lambdas.
It is mostly used for multi-arch builds purposes which we are not doing at the moment.

Setting the provenance to false seems to be the best workaround for us based on the comments found here: https://github.com/docker/buildx/issues/1509#issuecomment-1378538197
