### PR TITLE
fix: production tag is not moving

### DIFF
--- a/.github/workflows/ecs-deploy-v3.yml
+++ b/.github/workflows/ecs-deploy-v3.yml
@@ -145,7 +145,7 @@ jobs:
           echo "docker_image_tag=$TF_VAR_DOCKER_IMAGE_TAG" >> "$GITHUB_OUTPUT"
 
       - name: Add environment tag
-        if: github.ref_name == 'master'
+        if: github.ref_name == 'master' || github.ref_type == 'tag'
         uses: sencrop/github-workflows/actions/add-git-tag@master
         with:
           tag: ${{ inputs.environment }}

--- a/.github/workflows/terraform-deploy-v1.yml
+++ b/.github/workflows/terraform-deploy-v1.yml
@@ -125,7 +125,7 @@ jobs:
           slack_bot_token: ${{ secrets.SLACK_BOT_TOKEN }}
 
       - name: Add environment tag
-        if: github.ref_name == 'master'
+        if: github.ref_name == 'master' || github.ref_type == 'tag'
         uses: sencrop/github-workflows/actions/add-git-tag@master
         with:
           tag: ${{ inputs.environment }}


### PR DESCRIPTION
Since https://github.com/sencrop/github-workflows/pull/165 the `production` tag is not moving anymore, that's because a production release workflow is triggered from a tag and not from a branch