### PR TITLE
feat: add target-branch parameter

### DIFF
--- a/.github/workflows/release-please-v1.yml
+++ b/.github/workflows/release-please-v1.yml
@@ -43,3 +43,4 @@ jobs:
           token: ${{ steps.app_token.outputs.token }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+          target-branch: ${{ github.ref_name }}


### PR DESCRIPTION
Following the release please official documentation https://github.com/googleapis/release-please-action?tab=readme-ov-file#supporting-multiple-release-branches

This operation should be not breaking on every repos if they have only 
```
on:
  push:
    branches:
        - master
```
And this should help when having this configuration:
```
on:
  push:
    branches:
        - master
        - "v[0-9]+"
```
