### PR TITLE
ci(release-please): add permissions to write issues

### DIFF
--- a/.github/workflows/release-please-v1.yml
+++ b/.github/workflows/release-please-v1.yml
@@ -25,6 +25,7 @@ jobs:
       pr: ${{ steps.release_please.outputs.pr }}
     permissions:
       contents: write
+      issues: write
       pull-requests: write
     steps:
       - name: Checkout


### PR DESCRIPTION
This PR adds permissions for the `release-please` to create a new label, see https://github.com/googleapis/release-please-action/issues/1105.